### PR TITLE
update to 1.3.4

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = github-desktop-git
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 1.3.0_beta6
+	pkgver = 1.3.4
 	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
@@ -17,7 +17,7 @@ pkgbase = github-desktop-git
 	depends = libcurl-compat
 	depends = libcurl-gnutls
 	optdepends = hub: CLI interface for GitHub.
-	source = git+https://github.com/desktop/desktop.git#tag=release-1.3.0-beta6
+	source = git+https://github.com/desktop/desktop.git#tag=release-1.3.4
 	source = github-desktop.desktop
 	sha256sums = SKIP
 	sha256sums = be057e4a392e64760f7a40203ac886b7cf5551de254ad55c706376dca8aa4341

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,14 +4,14 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}-git"
-pkgver=1.3.0_beta6
+pkgver=1.3.4
 gitname="release-${pkgver//_/-}"
 pkgrel=1
 pkgdesc="GUI for managing Git and GitHub."
 arch=('x86_64')
 url="https://desktop.github.com"
 license=('MIT')
-depends=('gnome-keyring' 'git' 'electron' 'nodejs' 'libcurl-compat' 'libcurl-gnutls')
+depends=('gnome-keyring' 'git' 'electron' 'nodejs-lts-carbon' 'libcurl-compat' 'libcurl-gnutls')
 optdepends=('hub: CLI interface for GitHub.')
 makedepends=('libcurl-openssl-1.0' 'xorg-server-xvfb' 'yarn' 'python2' 'nvm')
 DLAGENTS=("http::/usr/bin/git clone --branch ${gitname} --single-branch %u")


### PR DESCRIPTION
Also targets `nodejs-lts-carbon` which is the latest `8.x` version of the toolchain (I think this should be a `makedepends` because Electron embeds it's own Node runtime, but we can follow up with that later).