### PR TITLE
bump version to 2.5.0-linux1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ services:
   - docker
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR/rel/:/pkg whynothugo/makepkg
   - docker run -v $TRAVIS_BUILD_DIR/bin/:/pkg whynothugo/makepkg
+  - docker run -v $TRAVIS_BUILD_DIR/rel/:/pkg whynothugo/makepkg
   - docker run -v $TRAVIS_BUILD_DIR/git/:/pkg whynothugo/makepkg

--- a/bin/.SRCINFO
+++ b/bin/.SRCINFO
@@ -22,3 +22,4 @@ pkgbase = github-desktop-bin
 	sha256sums = 2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 
 pkgname = github-desktop-bin
+

--- a/bin/.SRCINFO
+++ b/bin/.SRCINFO
@@ -18,7 +18,7 @@ pkgbase = github-desktop-bin
 	conflicts = github-desktop
 	source = https://github.com/shiftkey/desktop/releases/download/release-2.5.0-linux1/GitHubDesktop-linux-2.5.0-linux1.deb
 	source = github-desktop.desktop
-	sha256sums = 50dad19df211b726cf145121656aa608103b994d8de611977d95e0ef09ca2b25
+	sha256sums = bc2b60ec6fa1b66b1d229915e91b5f7f0a8c618e54ab3a9bf67ffad744907e4d
 	sha256sums = 2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 
 pkgname = github-desktop-bin

--- a/bin/.SRCINFO
+++ b/bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = github-desktop-bin
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 2.4.0
+	pkgver = 2.5.0
 	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
@@ -16,10 +16,9 @@ pkgbase = github-desktop-bin
 	optdepends = hub: CLI interface for GitHub.
 	provides = github-desktop
 	conflicts = github-desktop
-	source = https://github.com/shiftkey/desktop/releases/download/release-2.4.0-linux2/GitHubDesktop-linux-2.4.0-linux2.deb
+	source = https://github.com/shiftkey/desktop/releases/download/release-2.5.0-linux1/GitHubDesktop-linux-2.5.0-linux1.deb
 	source = github-desktop.desktop
 	sha256sums = 50dad19df211b726cf145121656aa608103b994d8de611977d95e0ef09ca2b25
 	sha256sums = 2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 
 pkgname = github-desktop-bin
-

--- a/bin/PKGBUILD
+++ b/bin/PKGBUILD
@@ -24,6 +24,7 @@ sha256sums=(
 )
 package() {
     tar xf data.tar.xz -C "${pkgdir}"
+    install -d "${pkgdir}/opt/${_pkgname}"
     mv "${pkgdir}/usr/lib/github-desktop" "${pkgdir}/opt/${_pkgname}"
     rm "${pkgdir}/usr/share/applications/github-desktop.desktop"
     install -Dm644 "${_pkgname}.desktop" "${pkgdir}/usr/share/applications/${_pkgname}.desktop"

--- a/bin/PKGBUILD
+++ b/bin/PKGBUILD
@@ -24,7 +24,7 @@ sha256sums=(
 )
 package() {
     tar xf data.tar.xz -C "${pkgdir}"
-    mv "${pkgdir}/opt/GitHub Desktop" "${pkgdir}/opt/${_pkgname}"
+    mv "${pkgdir}/usr/lib/github-desktop" "${pkgdir}/opt/${_pkgname}"
     rm "${pkgdir}/usr/share/applications/github-desktop.desktop"
     install -Dm644 "${_pkgname}.desktop" "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
     printf "#!/bin/sh\n\n/opt/${_pkgname}/github-desktop \"\$@\"\n" | install -Dm755 /dev/stdin "${pkgdir}/usr/bin/${_pkgname}"

--- a/bin/PKGBUILD
+++ b/bin/PKGBUILD
@@ -2,8 +2,8 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}-bin"
-pkgver=2.4.0
-_pkgver="${pkgver}-linux2"
+pkgver=2.5.0
+_pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
 pkgrel=1
 pkgdesc="GUI for managing Git and GitHub."

--- a/bin/PKGBUILD
+++ b/bin/PKGBUILD
@@ -19,7 +19,7 @@ source=(
     ${_pkgname}.desktop
 )
 sha256sums=(
-    50dad19df211b726cf145121656aa608103b994d8de611977d95e0ef09ca2b25
+    bc2b60ec6fa1b66b1d229915e91b5f7f0a8c618e54ab3a9bf67ffad744907e4d
     2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 )
 package() {

--- a/git/.SRCINFO
+++ b/git/.SRCINFO
@@ -9,6 +9,7 @@ pkgbase = github-desktop-git
 	makedepends = nodejs>=10.16.0
 	makedepends = yarn
 	makedepends = python2
+	makedepends = unzip
 	depends = gnome-keyring
 	depends = libsecret
 	depends = git
@@ -26,3 +27,4 @@ pkgbase = github-desktop-git
 	sha256sums = 2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 
 pkgname = github-desktop-git
+

--- a/git/.SRCINFO
+++ b/git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = github-desktop-git
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 2.4.0
+	pkgver = 2.5.0
 	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
@@ -26,4 +26,3 @@ pkgbase = github-desktop-git
 	sha256sums = 2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 
 pkgname = github-desktop-git
-

--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -14,7 +14,7 @@ url="https://desktop.github.com"
 license=('MIT')
 depends=('gnome-keyring' 'libsecret' 'git' 'curl' 'libxss' 'gconf' 'nss' 'nspr')
 optdepends=('hub: CLI interface for GitHub.')
-makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2')
+makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2' 'unzip')
 provides=(${_pkgname})
 conflicts=(${_pkgname})
 DLAGENTS=("https::/usr/bin/git clone --branch ${gitname} --single-branch %u")

--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -4,8 +4,8 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}-git"
-pkgver=2.4.0
-_pkgver="${pkgver}-linux2"
+pkgver=2.5.0
+_pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
 pkgrel=1
 pkgdesc="GUI for managing Git and GitHub."

--- a/rel/.SRCINFO
+++ b/rel/.SRCINFO
@@ -9,6 +9,7 @@ pkgbase = github-desktop
 	makedepends = nodejs>=10.16.0
 	makedepends = yarn
 	makedepends = python2
+	makedepends = unzip
 	depends = gnome-keyring
 	depends = libsecret
 	depends = git
@@ -24,3 +25,4 @@ pkgbase = github-desktop
 	sha256sums = 2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 
 pkgname = github-desktop
+

--- a/rel/.SRCINFO
+++ b/rel/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = github-desktop
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 2.4.0
+	pkgver = 2.5.0
 	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
@@ -18,10 +18,9 @@ pkgbase = github-desktop
 	depends = nss
 	depends = nspr
 	optdepends = hub: CLI interface for GitHub.
-	source = git+https://github.com/shiftkey/desktop.git#tag=release-2.4.0-linux2
+	source = git+https://github.com/shiftkey/desktop.git#tag=release-2.5.0-linux1
 	source = github-desktop.desktop
 	sha256sums = SKIP
 	sha256sums = 2758e15659f5770ae2ac948250372135029e7ac2d4b6bf431a112dfdbcc681d1
 
 pkgname = github-desktop
-

--- a/rel/PKGBUILD
+++ b/rel/PKGBUILD
@@ -4,8 +4,8 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}"
-pkgver=2.4.0
-_pkgver="${pkgver}-linux2"
+pkgver=2.5.0
+_pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
 pkgrel=1
 pkgdesc="GUI for managing Git and GitHub."

--- a/rel/PKGBUILD
+++ b/rel/PKGBUILD
@@ -14,7 +14,7 @@ url="https://desktop.github.com"
 license=('MIT')
 depends=('gnome-keyring' 'libsecret' 'git' 'curl' 'libxss' 'gconf' 'nss' 'nspr')
 optdepends=('hub: CLI interface for GitHub.')
-makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2')
+makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2' 'unzip')
 DLAGENTS=("http::/usr/bin/git clone --branch ${gitname} --single-branch %u")
 source=(
   git+https://github.com/shiftkey/desktop.git#tag=${gitname}


### PR DESCRIPTION
:wave: I hope all is well with you.

 - [x] bumped the packages for `2.5.0-linux1` that I published earlier in the week
 - [x] update `github-desktop-bin` script to handle install directory moving from `/opt/GitHub Desktop` to `/usr/lib/github-desktop` for release [`2.4.1-linux2`](https://github.com/shiftkey/desktop/releases/tag/release-2.4.1-linux2)
 - [x] validate packages locally using docker
 - ~[ ] investigate CI failures~

Let me know if there's anything else I can help with.