### PR TITLE
drop nested github-desktop when copying directory

### DIFF
--- a/bin/PKGBUILD
+++ b/bin/PKGBUILD
@@ -5,7 +5,7 @@ pkgname="${_pkgname}-bin"
 pkgver=2.5.2
 _pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
-pkgrel=1
+pkgrel=2
 pkgdesc="GUI for managing Git and GitHub."
 arch=('x86_64')
 url="https://desktop.github.com"
@@ -25,7 +25,7 @@ sha256sums=(
 package() {
     tar xf data.tar.xz -C "${pkgdir}"
     install -d "${pkgdir}/opt/${_pkgname}"
-    mv "${pkgdir}/usr/lib/github-desktop" "${pkgdir}/opt/${_pkgname}"
+    mv "${pkgdir}/usr/lib/github-desktop" "${pkgdir}/opt/"
     rm "${pkgdir}/usr/share/applications/github-desktop.desktop"
     install -Dm644 "${_pkgname}.desktop" "${pkgdir}/usr/share/applications/${_pkgname}.desktop"
     printf "#!/bin/sh\n\n/opt/${_pkgname}/github-desktop \"\$@\"\n" | install -Dm755 /dev/stdin "${pkgdir}/usr/bin/${_pkgname}"


### PR DESCRIPTION
I believe this is the fix for these issues reported on the AUR:

 - https://aur.archlinux.org/packages/github-desktop-bin/#comment-751040
 - https://aur.archlinux.org/packages/github-desktop/#comment-751042

The `rel` and `git` packages do not rely on the install directory change from the debian package, and I'll rebuild the `rel` package using `makepkg` to confirm the directory structure is still correct.

 - [x] verify `bin` package is hosted at `/opt/github-desktop/`
 - [x] verify `rel` package is hosted at `/opt/github-desktop/`
 - [x] verify `git` package is hosted at `/opt/github-desktop/`