### PR TITLE
update to latest release for Linux

### DIFF
--- a/bin/.SRCINFO
+++ b/bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = github-desktop-bin
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 2.5.3
+	pkgver = 2.5.4
 	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
@@ -17,10 +17,9 @@ pkgbase = github-desktop-bin
 	optdepends = hub: CLI interface for GitHub.
 	provides = github-desktop
 	conflicts = github-desktop
-	source = https://github.com/shiftkey/desktop/releases/download/release-2.5.3-linux1/GitHubDesktop-linux-2.5.3-linux1.deb
+	source = https://github.com/shiftkey/desktop/releases/download/release-2.5.4-linux1/GitHubDesktop-linux-2.5.4-linux1.deb
 	source = github-desktop.desktop
-	sha256sums = 762c97c03896715469b188d5f9f3b5d3e09a016671de3e39285b0ee295abca49
+	sha256sums = ebd85fe551137dc5606cbe33bbec812125a87c6dbbe31664ccf07a8dc186818c
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 
 pkgname = github-desktop-bin
-

--- a/bin/PKGBUILD
+++ b/bin/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}-bin"
-pkgver=2.5.3
+pkgver=2.5.4
 _pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
 pkgrel=1
@@ -19,7 +19,7 @@ source=(
     ${_pkgname}.desktop
 )
 sha256sums=(
-    762c97c03896715469b188d5f9f3b5d3e09a016671de3e39285b0ee295abca49
+    ebd85fe551137dc5606cbe33bbec812125a87c6dbbe31664ccf07a8dc186818c
     932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 )
 package() {

--- a/git/.SRCINFO
+++ b/git/.SRCINFO
@@ -7,6 +7,7 @@ pkgbase = github-desktop-git
 	license = MIT
 	makedepends = xorg-server-xvfb
 	makedepends = nodejs>=10.16.0
+	makedepends = npm
 	makedepends = yarn
 	makedepends = python2
 	makedepends = unzip
@@ -28,4 +29,3 @@ pkgbase = github-desktop-git
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 
 pkgname = github-desktop-git
-

--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -13,7 +13,7 @@ url="https://desktop.github.com"
 license=('MIT')
 depends=('gnome-keyring' 'libsecret' 'git' 'curl' 'libxss' 'gconf' 'nss' 'nspr' 'unzip')
 optdepends=('hub: CLI interface for GitHub.')
-makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2' 'unzip')
+makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'npm' 'yarn' 'python2' 'unzip')
 provides=(${_pkgname})
 conflicts=(${_pkgname})
 DLAGENTS=("https::/usr/bin/git clone --branch ${gitname} --single-branch %u")

--- a/rel/.SRCINFO
+++ b/rel/.SRCINFO
@@ -7,6 +7,7 @@ pkgbase = github-desktop
 	license = MIT
 	makedepends = xorg-server-xvfb
 	makedepends = nodejs>=10.16.0
+	makedepends = npm
 	makedepends = yarn
 	makedepends = python2
 	makedepends = unzip

--- a/rel/.SRCINFO
+++ b/rel/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = github-desktop
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 2.5.3
+	pkgver = 2.5.4
 	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
@@ -20,10 +20,9 @@ pkgbase = github-desktop
 	depends = nspr
 	depends = unzip
 	optdepends = hub: CLI interface for GitHub.
-	source = git+https://github.com/shiftkey/desktop.git#tag=release-2.5.3-linux1
+	source = git+https://github.com/shiftkey/desktop.git#tag=release-2.5.4-linux1
 	source = github-desktop.desktop
 	sha256sums = SKIP
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 
 pkgname = github-desktop
-

--- a/rel/PKGBUILD
+++ b/rel/PKGBUILD
@@ -14,7 +14,7 @@ url="https://desktop.github.com"
 license=('MIT')
 depends=('gnome-keyring' 'libsecret' 'git' 'curl' 'libxss' 'gconf' 'nss' 'nspr' 'unzip')
 optdepends=('hub: CLI interface for GitHub.')
-makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2' 'unzip')
+makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'npm' 'yarn' 'python2' 'unzip')
 DLAGENTS=("http::/usr/bin/git clone --branch ${gitname} --single-branch %u")
 source=(
   git+https://github.com/shiftkey/desktop.git#tag=${gitname}

--- a/rel/PKGBUILD
+++ b/rel/PKGBUILD
@@ -4,7 +4,7 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}"
-pkgver=2.5.3
+pkgver=2.5.4
 _pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
 pkgrel=1


### PR DESCRIPTION
Release notes: https://github.com/shiftkey/desktop/releases/tag/release-2.5.4-linux1

 - [x] CI passes for each `PKGBUILD`
 - [x] test `rel` package in VM