### PR TITLE
add npm package so that node-gyp is available for scripts

### DIFF
--- a/git/.SRCINFO
+++ b/git/.SRCINFO
@@ -7,6 +7,7 @@ pkgbase = github-desktop-git
 	license = MIT
 	makedepends = xorg-server-xvfb
 	makedepends = nodejs>=10.16.0
+	makedepends = npm
 	makedepends = yarn
 	makedepends = python2
 	makedepends = unzip
@@ -28,4 +29,3 @@ pkgbase = github-desktop-git
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 
 pkgname = github-desktop-git
-

--- a/git/PKGBUILD
+++ b/git/PKGBUILD
@@ -13,7 +13,7 @@ url="https://desktop.github.com"
 license=('MIT')
 depends=('gnome-keyring' 'libsecret' 'git' 'curl' 'libxss' 'gconf' 'nss' 'nspr' 'unzip')
 optdepends=('hub: CLI interface for GitHub.')
-makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2' 'unzip')
+makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'npm' 'yarn' 'python2' 'unzip')
 provides=(${_pkgname})
 conflicts=(${_pkgname})
 DLAGENTS=("https::/usr/bin/git clone --branch ${gitname} --single-branch %u")

--- a/rel/.SRCINFO
+++ b/rel/.SRCINFO
@@ -7,6 +7,7 @@ pkgbase = github-desktop
 	license = MIT
 	makedepends = xorg-server-xvfb
 	makedepends = nodejs>=10.16.0
+	makedepends = npm
 	makedepends = yarn
 	makedepends = python2
 	makedepends = unzip
@@ -26,4 +27,3 @@ pkgbase = github-desktop
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 
 pkgname = github-desktop
-

--- a/rel/PKGBUILD
+++ b/rel/PKGBUILD
@@ -14,7 +14,7 @@ url="https://desktop.github.com"
 license=('MIT')
 depends=('gnome-keyring' 'libsecret' 'git' 'curl' 'libxss' 'gconf' 'nss' 'nspr' 'unzip')
 optdepends=('hub: CLI interface for GitHub.')
-makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'yarn' 'python2' 'unzip')
+makedepends=('xorg-server-xvfb' 'nodejs>=10.16.0' 'npm' 'yarn' 'python2' 'unzip')
 DLAGENTS=("http::/usr/bin/git clone --branch ${gitname} --single-branch %u")
 source=(
   git+https://github.com/shiftkey/desktop.git#tag=${gitname}


### PR DESCRIPTION
I've fixed this in #9 but it seem like we're on a later version, so this should fix the CI issue.

I'm working on a new release, so once that's available I'll organize a fresh PR for this repository too.