### PR TITLE
bump version and checksum for new release

### DIFF
--- a/bin/.SRCINFO
+++ b/bin/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = github-desktop-bin
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 2.6.1
-	pkgrel = 2
+	pkgver = 2.6.2
+	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
 	license = MIT
@@ -17,10 +17,9 @@ pkgbase = github-desktop-bin
 	optdepends = hub: CLI interface for GitHub.
 	provides = github-desktop
 	conflicts = github-desktop
-	source = https://github.com/shiftkey/desktop/releases/download/release-2.6.1-linux2/GitHubDesktop-linux-2.6.1-linux2.deb
+	source = https://github.com/shiftkey/desktop/releases/download/release-2.6.2-linux1/GitHubDesktop-linux-2.6.2-linux1.deb
 	source = github-desktop.desktop
-	sha256sums = a43c188f8fd326499b5c1d4099239f658ebac8e9a21001481407cccafcd5f208
+	sha256sums = c2f83dc5e078546886342fea041f5cce28f79ecb60745dab9b0256b3dc9960dc
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 
 pkgname = github-desktop-bin
-

--- a/bin/PKGBUILD
+++ b/bin/PKGBUILD
@@ -2,10 +2,10 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}-bin"
-pkgver=2.6.1
-_pkgver="${pkgver}-linux2"
+pkgver=2.6.2
+_pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
-pkgrel=2
+pkgrel=1
 pkgdesc="GUI for managing Git and GitHub."
 arch=('x86_64')
 url="https://desktop.github.com"
@@ -19,7 +19,7 @@ source=(
     ${_pkgname}.desktop
 )
 sha256sums=(
-    a43c188f8fd326499b5c1d4099239f658ebac8e9a21001481407cccafcd5f208
+    c2f83dc5e078546886342fea041f5cce28f79ecb60745dab9b0256b3dc9960dc
     932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 )
 package() {

--- a/rel/.SRCINFO
+++ b/rel/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = github-desktop
 	pkgdesc = GUI for managing Git and GitHub.
-	pkgver = 2.6.1
-	pkgrel = 2
+	pkgver = 2.6.2
+	pkgrel = 1
 	url = https://desktop.github.com
 	arch = x86_64
 	license = MIT
@@ -21,10 +21,9 @@ pkgbase = github-desktop
 	depends = nspr
 	depends = unzip
 	optdepends = hub: CLI interface for GitHub.
-	source = git+https://github.com/shiftkey/desktop.git#tag=release-2.6.1-linux2
+	source = git+https://github.com/shiftkey/desktop.git#tag=release-2.6.2-linux1
 	source = github-desktop.desktop
 	sha256sums = SKIP
 	sha256sums = 932e4c456e8c6db03d27172cf0daa37806bf025bb560d8b3d758c0997d1a618c
 
 pkgname = github-desktop
-

--- a/rel/PKGBUILD
+++ b/rel/PKGBUILD
@@ -4,10 +4,10 @@
 
 _pkgname='github-desktop'
 pkgname="${_pkgname}"
-pkgver=2.6.1
-_pkgver="${pkgver}-linux2"
+pkgver=2.6.2
+_pkgver="${pkgver}-linux1"
 gitname="release-${_pkgver}"
-pkgrel=2
+pkgrel=1
 pkgdesc="GUI for managing Git and GitHub."
 arch=('x86_64')
 url="https://desktop.github.com"


### PR DESCRIPTION
Release notes: https://github.com/shiftkey/desktop/releases/tag/release-2.6.2-linux1